### PR TITLE
Return error response with exception

### DIFF
--- a/AmazonAdvertisingApi/Client.php
+++ b/AmazonAdvertisingApi/Client.php
@@ -83,7 +83,7 @@ class Client
         if (array_key_exists("access_token", $response_array)) {
             $this->config["accessToken"] = $response_array["access_token"];
         } else {
-            $this->_logAndThrow("Unable to refresh token. 'access_token' not found in response. ". print_r($response));
+            $this->_logAndThrow("Unable to refresh token. 'access_token' not found in response. ". print_r($response, true));
         }
 
         return $response;


### PR DESCRIPTION
Return `$response` with exception rather than returning `1` and echoing `$response` to console.

Current:
print_r() echo
`Array
(
    [success] =>
    [code] => 400
    [response] => {"error_description":"Not authorized for requested operation","error":"unauthorized_client"}
    [requestId] => 0
)`
$e->getMessage()
`Unable to refresh token. 'access_token' not found in response. 1`

Expected:
$e->getMessage()
`Unable to refresh token. 'access_token' not found in response. Array
(
    [success] =>
    [code] => 400
    [response] => {"error_description":"Not authorized for requested operation","error":"unauthorized_client"}
    [requestId] => 0
)`